### PR TITLE
feat(MAT-3): Set up Docker environment with production and development configurations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+# Install system dependencies including PostgreSQL
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    python3-dev \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Rest of your Dockerfile remains the same
+COPY requirements.txt .
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+
+
+# Copy all files (including entrypoint.sh from parent folder)
+COPY . .
+
+# Set execute permissions properly
+RUN chmod +x /app/entrypoint.sh && \
+    chown -R 1000:1000 /app
+# Create non-root user
+RUN useradd -m myuser && chown -R myuser:myuser /app
+USER root
+RUN apt-get update && apt-get install -y curl wget
+USER myuser
+
+
+EXPOSE 8000
+
+# Use entrypoint from the copied location
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,23 @@
+version: "3.8"
+
+services:
+  mathery_api_prod:
+    image: mathery-api-prod:latest
+    ports:
+      - "8010:8010"
+    env_file:
+      - .env
+    environment:
+      - ENV=production
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 3G
+    restart: unless-stopped
+    networks:
+      - my_network_prod
+
+networks:
+  my_network_prod:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.8"
+
+services:
+  web:
+    build: .
+    container_name: mathery-api
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/app
+      - ~/.aws:/home/myuser/.aws
+    env_file:
+      - .env
+    networks:
+      - my_network
+
+networks:
+  my_network:
+    driver: bridge

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+if [ "$ENV" = "production" ]; then
+    echo "Running in production mode with Gunicorn"
+    exec gunicorn -k uvicorn.workers.UvicornWorker main:app \
+        --bind 0.0.0.0:8010 \
+        --workers 1 \
+        --threads 2 \
+        --timeout 120
+elif [ "$ENV" = "testing" ]; then
+    echo "Running in testing mode with Gunicorn"
+    exec gunicorn -k uvicorn.workers.UvicornWorker main:app \
+        --bind 0.0.0.0:8002 \
+        --workers 1 \
+        --timeout 120
+else
+    echo "Running in development mode with Uvicorn"
+    exec uvicorn main:app \
+        --host 0.0.0.0 \
+        --port 8000 \
+        --reload
+fi
+


### PR DESCRIPTION
This pull request introduces a Dockerized setup for the project, including production and development environments, along with an entrypoint script to handle different runtime modes. The most important changes include the addition of a `Dockerfile`, new `docker-compose` configurations for development and production, and an entrypoint script to manage environment-specific behavior.

### Dockerization:

* **`Dockerfile`:** Added a `Dockerfile` to define the application's container image, including dependencies, user permissions, and entrypoint configuration. It uses the `python:3.13-slim` base image and installs system dependencies like PostgreSQL libraries and `pip` requirements.

* **`docker-compose.yml`:** Added a development `docker-compose` configuration to build the container, map ports, mount volumes, and set up a development network.

* **`docker-compose.prod.yml`:** Added a production `docker-compose` configuration to deploy the application with resource limits, environment variables, and a production network.

### Runtime Environment Management:

* **`entrypoint.sh`:** Added an entrypoint script to handle different runtime modes (`production`, `testing`, and `development`) using either Gunicorn or Uvicorn, depending on the environment.